### PR TITLE
feature: fallback to pre-release when no stable version is found

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -149,6 +149,35 @@ jobs:
     - name: Run simple code
       run: python -c 'import math; print(math.factorial(5))'
 
+  setup-prerelease-version:
+    name: Setup 3.12 ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest, ubuntu-latest]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: setup-python 3.12
+      id: setup-python
+      uses: ./
+      with:
+        python-version: '3.12'
+        allow-prereleases: true
+
+    - name: Check python-path
+      run: ./__tests__/check-python-path.sh '${{ steps.setup-python.outputs.python-path }}'
+      shell: bash
+
+    - name: Validate version
+      run: ${{ startsWith(steps.setup-python.outputs.python-version, '3.12.') }}
+      shell: bash
+
+    - name: Run simple code
+      run: python -c 'import math; print(math.factorial(5))'
+
   setup-versions-noenv:
     name: Setup ${{ matrix.python }} ${{ matrix.os }} (noenv)
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ See examples of using `cache` and `cache-dependency-path` for `pipenv` and `poet
 - [Hosted tool cache](docs/advanced-usage.md#hosted-tool-cache) 
 - [Using `setup-python` with a self-hosted runner](docs/advanced-usage.md#using-setup-python-with-a-self-hosted-runner)
 - [Using `setup-python` on GHES](docs/advanced-usage.md#using-setup-python-on-ghes)
+- [Allow pre-releases](docs/advanced-usage.md#allow-pre-releases)
 
 ## License
 

--- a/__tests__/data/pypy.json
+++ b/__tests__/data/pypy.json
@@ -1,5 +1,95 @@
 [
   {
+    "pypy_version": "7.3.8rc2",
+    "python_version": "3.8.12",
+    "stable": false,
+    "latest_pypy": false,
+    "date": "2022-02-11",
+    "files": [
+      {
+        "filename": "pypy3.8-v7.3.8rc2-linux32.tar.bz2",
+        "arch": "i686",
+        "platform": "linux",
+        "download_url": "https://test.download.python.org/pypy/pypy3.8-v7.3.8rc2-linux32.tar.bz2"
+      },
+      {
+        "filename": "pypy3.8-v7.3.8rc2-linux64.tar.bz2",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://test.download.python.org/pypy/pypy3.8-v7.3.8rc2-linux64.tar.bz2"
+      },
+      {
+        "filename": "pypy3.8-v7.3.8rc2-darwin64.tar.bz2",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://test.download.python.org/pypy/pypy3.8-v7.3.8rc2-darwin64.tar.bz2"
+      },
+      {
+        "filename": "pypy3.8-v7.3.8rc2-s390x.tar.bz2",
+        "arch": "s390x",
+        "platform": "linux",
+        "download_url": "https://test.download.python.org/pypy/pypy3.8-v7.3.8rc2-s390x.tar.bz2"
+      },
+      {
+        "filename": "pypy3.8-v7.3.8rc2-win64.zip",
+        "arch": "x64",
+        "platform": "win64",
+        "download_url": "https://test.download.python.org/pypy/pypy3.8-v7.3.8rc2-win64.zip"
+      },
+      {
+        "filename": "pypy3.8-v7.3.8rc2-win32.zip",
+        "arch": "x86",
+        "platform": "win32",
+        "download_url": "https://test.download.python.org/pypy/pypy3.8-v7.3.8rc2-win32.zip"
+      }
+    ]
+  },
+  {
+    "pypy_version": "7.4.0rc1",
+    "python_version": "3.6.12",
+    "stable": false,
+    "latest_pypy": false,
+    "date": "2021-11-11",
+    "files": [
+      {
+        "filename": "pypy3.6-v7.4.0rc1-aarch64.tar.bz2",
+        "arch": "aarch64",
+        "platform": "linux",
+        "download_url": "https://test.download.python.org/pypy/pypy3.6-v7.4.0rc1-aarch64.tar.bz2"
+      },
+      {
+        "filename": "pypy3.6-v7.4.0rc1-linux32.tar.bz2",
+        "arch": "i686",
+        "platform": "linux",
+        "download_url": "https://test.download.python.org/pypy/pypy3.6-v7.4.0rc1-linux32.tar.bz2"
+      },
+      {
+        "filename": "pypy3.6-v7.4.0rc1-linux64.tar.bz2",
+        "arch": "x64",
+        "platform": "linux",
+        "download_url": "https://test.download.python.org/pypy/pypy3.6-v7.4.0rc1-linux64.tar.bz2"
+      },
+      {
+        "filename": "pypy3.6-v7.4.0rc1-darwin64.tar.bz2",
+        "arch": "x64",
+        "platform": "darwin",
+        "download_url": "https://test.download.python.org/pypy/pypy3.6-v7.4.0rc1-darwin64.tar.bz2"
+      },
+      {
+        "filename": "pypy3.6-v7.4.0rc1-win32.zip",
+        "arch": "x86",
+        "platform": "win32",
+        "download_url": "https://test.download.python.org/pypy/pypy3.6-v7.4.0rc1-win32.zip"
+      },
+      {
+        "filename": "pypy3.6-v7.4.0rc1-s390x.tar.bz2",
+        "arch": "s390x",
+        "platform": "linux",
+        "download_url": "https://test.download.python.org/pypy/pypy3.6-v7.4.0rc1-s390x.tar.bz2"
+      }
+    ]
+  },
+  {
     "pypy_version": "7.3.3",
     "python_version": "3.6.12",
     "stable": true,

--- a/__tests__/data/versions-manifest.json
+++ b/__tests__/data/versions-manifest.json
@@ -1,5 +1,30 @@
 [
     {
+      "version": "1.2.4-beta.2",
+      "stable": false,
+      "release_url": "https://github.com/actions/sometool/releases/tag/1.2.4-beta.2-20200402.5",
+      "files": [
+        {
+          "filename": "sometool-1.2.4-linux-x64.tar.gz",
+          "arch": "x64",
+          "platform": "linux",
+          "download_url": "https://github.com/actions/sometool/releases/tag/1.2.4-beta.2-20200402.5/sometool-1.2.4-linux-x64.tar.gz"
+        },
+        {
+          "filename": "sometool-1.2.4-darwin-x64.tar.gz",
+          "arch": "x64",
+          "platform": "darwin",
+          "download_url": "https://github.com/actions/sometool/releases/tag/1.2.4-beta.2-20200402.5/sometool-1.2.4-darwin-x64.tar.gz"
+        },
+        {
+          "filename": "sometool-1.2.4-win32-x64.tar.gz",
+          "arch": "x64",
+          "platform": "win32",
+          "download_url": "https://github.com/actions/sometool/releases/tag/1.2.4-beta.2-20200402.5/sometool-1.2.4-win32-x64.tar.gz"
+        }
+      ]
+    },
+    {
       "version": "1.2.3",
       "stable": true,
       "release_url": "https://github.com/actions/sometool/releases/tag/1.2.3-20200402.6",
@@ -25,27 +50,27 @@
       ]
     },
     {
-      "version": "1.2.3-beta.2",
+      "version": "1.1.0-beta.2",
       "stable": false,
-      "release_url": "https://github.com/actions/sometool/releases/tag/1.2.3-beta.2-20200402.5",
+      "release_url": "https://github.com/actions/sometool/releases/tag/1.1.0-beta.2-20200402.5",
       "files": [
         {
-          "filename": "sometool-1.2.3-linux-x64.tar.gz",
+          "filename": "sometool-1.1.0-linux-x64.tar.gz",
           "arch": "x64",
           "platform": "linux",
-          "download_url": "https://github.com/actions/sometool/releases/tag/1.2.3-beta.2-20200402.5/sometool-1.2.3-linux-x64.tar.gz"
+          "download_url": "https://github.com/actions/sometool/releases/tag/1.1.0-beta.2-20200402.5/sometool-1.1.0-linux-x64.tar.gz"
         },
         {
-          "filename": "sometool-1.2.3-darwin-x64.tar.gz",
+          "filename": "sometool-1.1.0-darwin-x64.tar.gz",
           "arch": "x64",
           "platform": "darwin",
-          "download_url": "https://github.com/actions/sometool/releases/tag/1.2.3-20200402.5/sometool-1.2.3-darwin-x64.tar.gz"
+          "download_url": "https://github.com/actions/sometool/releases/tag/1.1.0-beta.2-20200402.5/sometool-1.1.0-darwin-x64.tar.gz"
         },
         {
-          "filename": "sometool-1.2.3-win32-x64.tar.gz",
+          "filename": "sometool-1.1.0-win32-x64.tar.gz",
           "arch": "x64",
           "platform": "win32",
-          "download_url": "https://github.com/actions/sometool/releases/tag/1.2.3-20200402.5/sometool-1.2.3-win32-x64.tar.gz"
+          "download_url": "https://github.com/actions/sometool/releases/tag/1.1.0-beta.2-20200402.5/sometool-1.1.0-win32-x64.tar.gz"
         }
       ]
     }

--- a/__tests__/find-pypy.test.ts
+++ b/__tests__/find-pypy.test.ts
@@ -273,7 +273,13 @@ describe('findPyPyVersion', () => {
 
   it('found PyPy in toolcache', async () => {
     await expect(
-      finder.findPyPyVersion('pypy-3.6-v7.3.x', architecture, true, false)
+      finder.findPyPyVersion(
+        'pypy-3.6-v7.3.x',
+        architecture,
+        true,
+        false,
+        false
+      )
     ).resolves.toEqual({
       resolvedPythonVersion: '3.6.12',
       resolvedPyPyVersion: '7.3.3'
@@ -291,13 +297,13 @@ describe('findPyPyVersion', () => {
 
   it('throw on invalid input format', async () => {
     await expect(
-      finder.findPyPyVersion('pypy3.7-v7.3.x', architecture, true, false)
+      finder.findPyPyVersion('pypy3.7-v7.3.x', architecture, true, false, false)
     ).rejects.toThrow();
   });
 
   it('throw on invalid input format pypy3.7-7.3.x', async () => {
     await expect(
-      finder.findPyPyVersion('pypy3.7-v7.3.x', architecture, true, false)
+      finder.findPyPyVersion('pypy3.7-v7.3.x', architecture, true, false, false)
     ).rejects.toThrow();
   });
 
@@ -309,7 +315,13 @@ describe('findPyPyVersion', () => {
     spyChmodSync = jest.spyOn(fs, 'chmodSync');
     spyChmodSync.mockImplementation(() => undefined);
     await expect(
-      finder.findPyPyVersion('pypy-3.7-v7.3.x', architecture, true, false)
+      finder.findPyPyVersion(
+        'pypy-3.7-v7.3.x',
+        architecture,
+        true,
+        false,
+        false
+      )
     ).resolves.toEqual({
       resolvedPythonVersion: '3.7.9',
       resolvedPyPyVersion: '7.3.3'
@@ -333,7 +345,13 @@ describe('findPyPyVersion', () => {
     spyChmodSync = jest.spyOn(fs, 'chmodSync');
     spyChmodSync.mockImplementation(() => undefined);
     await expect(
-      finder.findPyPyVersion('pypy-3.7-v7.3.x', architecture, false, false)
+      finder.findPyPyVersion(
+        'pypy-3.7-v7.3.x',
+        architecture,
+        false,
+        false,
+        false
+      )
     ).resolves.toEqual({
       resolvedPythonVersion: '3.7.9',
       resolvedPyPyVersion: '7.3.3'
@@ -344,7 +362,13 @@ describe('findPyPyVersion', () => {
 
   it('throw if release is not found', async () => {
     await expect(
-      finder.findPyPyVersion('pypy-3.7-v7.5.x', architecture, true, false)
+      finder.findPyPyVersion(
+        'pypy-3.7-v7.5.x',
+        architecture,
+        true,
+        false,
+        false
+      )
     ).rejects.toThrowError(
       `PyPy version 3.7 (v7.5.x) with arch ${architecture} not found`
     );
@@ -352,7 +376,13 @@ describe('findPyPyVersion', () => {
 
   it('check-latest enabled version found and used from toolcache', async () => {
     await expect(
-      finder.findPyPyVersion('pypy-3.6-v7.3.x', architecture, false, true)
+      finder.findPyPyVersion(
+        'pypy-3.6-v7.3.x',
+        architecture,
+        false,
+        true,
+        false
+      )
     ).resolves.toEqual({
       resolvedPythonVersion: '3.6.12',
       resolvedPyPyVersion: '7.3.3'
@@ -371,7 +401,13 @@ describe('findPyPyVersion', () => {
     spyChmodSync = jest.spyOn(fs, 'chmodSync');
     spyChmodSync.mockImplementation(() => undefined);
     await expect(
-      finder.findPyPyVersion('pypy-3.7-v7.3.x', architecture, false, true)
+      finder.findPyPyVersion(
+        'pypy-3.7-v7.3.x',
+        architecture,
+        false,
+        true,
+        false
+      )
     ).resolves.toEqual({
       resolvedPythonVersion: '3.7.9',
       resolvedPyPyVersion: '7.3.3'
@@ -391,7 +427,13 @@ describe('findPyPyVersion', () => {
       return pypyPath;
     });
     await expect(
-      finder.findPyPyVersion('pypy-3.8-v7.3.x', architecture, false, true)
+      finder.findPyPyVersion(
+        'pypy-3.8-v7.3.x',
+        architecture,
+        false,
+        true,
+        false
+      )
     ).resolves.toEqual({
       resolvedPythonVersion: '3.8.8',
       resolvedPyPyVersion: '7.3.3'
@@ -400,5 +442,23 @@ describe('findPyPyVersion', () => {
     expect(infoSpy).toHaveBeenCalledWith(
       'Failed to resolve PyPy v7.3.x with Python (3.8) from manifest'
     );
+  });
+
+  it('found and install successfully, pre-release fallback', async () => {
+    spyCacheDir = jest.spyOn(tc, 'cacheDir');
+    spyCacheDir.mockImplementation(() =>
+      path.join(toolDir, 'PyPy', '3.8.12', architecture)
+    );
+    spyChmodSync = jest.spyOn(fs, 'chmodSync');
+    spyChmodSync.mockImplementation(() => undefined);
+    await expect(
+      finder.findPyPyVersion('pypy3.8', architecture, false, false, false)
+    ).rejects.toThrowError();
+    await expect(
+      finder.findPyPyVersion('pypy3.8', architecture, false, false, true)
+    ).resolves.toEqual({
+      resolvedPythonVersion: '3.8.12',
+      resolvedPyPyVersion: '7.3.8rc2'
+    });
   });
 });

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   update-environment:
     description: "Set this option if you want the action to update environment variables."
     default: true
+  allow-prereleases:
+    description: "When 'true', a version range passed to 'python-version' input will match prerelease versions if no GA versions are found. Only 'x.y' version range is supported for CPython."
+    default: false
 outputs:
   python-version:
     description: "The installed Python or PyPy version. Useful when given a version range as input."

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -20,6 +20,7 @@
     - [Linux](advanced-usage.md#linux)
     - [macOS](advanced-usage.md#macos)
 - [Using `setup-python` on GHES](advanced-usage.md#using-setup-python-on-ghes)
+- [Allow pre-releases](advanced-usage.md#allow-pre-releases)
 
 ## Using the `python-version` input
 
@@ -568,3 +569,31 @@ Requests should now be authenticated. To verify that you are getting the higher 
 
 ### No access to github.com
 If the runner is not able to access github.com, any Python versions requested during a workflow run must come from the runner's tool cache. See "[Setting up the tool cache on self-hosted runners without internet access](https://docs.github.com/en/enterprise-server@3.2/admin/github-actions/managing-access-to-actions-from-githubcom/setting-up-the-tool-cache-on-self-hosted-runners-without-internet-access)" for more information.
+
+
+## Allow pre-releases
+
+The `allow-prereleases` flag defaults to `false`.
+If `allow-prereleases` is set to `true`, the action will allow falling back to pre-release versions of Python when a matching GA version of Python is not available.
+This allows for example to simplify reuse of `python-version` as an input of nox for pre-releases of Python by not requiring manipulation of the `3.y-dev` specifier.
+For CPython, `allow-prereleases` will only have effect for `x.y` version range (e.g. `3.12`).
+Let's say that python 3.12 is not generally available, the following workflow will fallback to the most recent pre-release of python 3.12:
+```yaml
+jobs:
+  test:
+    name: ${{ matrix.os }} / ${{ matrix.python_version }}
+    runs-on: ${{ matrix.os }}-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [Ubuntu, Windows, macOS]
+        python_version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "${{ matrix.python_version }}"
+      - run: pipx run nox --error-on-missing-interpreters -s tests-${{ matrix.python_version }}
+```
+

--- a/src/find-pypy.ts
+++ b/src/find-pypy.ts
@@ -23,7 +23,8 @@ export async function findPyPyVersion(
   versionSpec: string,
   architecture: string,
   updateEnvironment: boolean,
-  checkLatest: boolean
+  checkLatest: boolean,
+  allowPreReleases: boolean
 ): Promise<{resolvedPyPyVersion: string; resolvedPythonVersion: string}> {
   let resolvedPyPyVersion = '';
   let resolvedPythonVersion = '';
@@ -39,7 +40,8 @@ export async function findPyPyVersion(
         releases,
         pypyVersionSpec.pythonVersion,
         pypyVersionSpec.pypyVersion,
-        architecture
+        architecture,
+        false
       );
 
       if (releaseData) {
@@ -71,6 +73,7 @@ export async function findPyPyVersion(
       pypyVersionSpec.pypyVersion,
       pypyVersionSpec.pythonVersion,
       architecture,
+      allowPreReleases,
       releases
     ));
   }

--- a/src/setup-python.ts
+++ b/src/setup-python.ts
@@ -77,6 +77,7 @@ async function run() {
   try {
     const versions = resolveVersionInput();
     const checkLatest = core.getBooleanInput('check-latest');
+    const allowPreReleases = core.getBooleanInput('allow-prereleases');
 
     if (versions.length) {
       let pythonVersion = '';
@@ -89,7 +90,8 @@ async function run() {
             version,
             arch,
             updateEnvironment,
-            checkLatest
+            checkLatest,
+            allowPreReleases
           );
           pythonVersion = `${installed.resolvedPyPyVersion}-${installed.resolvedPythonVersion}`;
           core.info(
@@ -100,7 +102,8 @@ async function run() {
             version,
             arch,
             updateEnvironment,
-            checkLatest
+            checkLatest,
+            allowPreReleases
           );
           pythonVersion = installed.version;
           core.info(`Successfully set up ${installed.impl} (${pythonVersion})`);


### PR DESCRIPTION
This allows to specify version like `3.11` or `pypy3.10` in workflows before those versions are released.
This lessen the burden for users of `setup-python` by not having to modify their workflow twice: once when a pre-release is available (e.g. `3.11-dev`) and once when the first stable release is published (e.g. `3.11`)

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.