### PR TITLE
fix(ci): test non EOL python versions

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ${{ matrix.operating-system }}
     strategy:
       matrix:
-        operating-system: [ubuntu-latest, windows-latest]
+        operating-system: [ubuntu-20.04, windows-latest]
     steps:
     - name: Checkout
       uses: actions/checkout@v3
@@ -68,7 +68,7 @@ jobs:
         python-version: 3.8
     - name: Verify 3.8
       run: python __tests__/verify-python.py 3.8
-    
+
     - name: Run with setup-python 3.7.5
       uses: ./
       with:


### PR DESCRIPTION
With ubuntu-latest moving to 22.04, there's a number of EOL python versions that are not available anymore. Upgrade all python versions in `.github/workflows/workflow.yml` to get available versions.

**Description:**
Describe your changes.

**Related issue:**
Add link to the related issue.

**Check list:**
- [ ] Mark if documentation changes are required.
- [ ] Mark if tests were added or updated to cover the changes.